### PR TITLE
Added stuff to logmon & cmdmon

### DIFF
--- a/cmdmon/cmdmon.go
+++ b/cmdmon/cmdmon.go
@@ -144,6 +144,7 @@ func FindDeviousCmd(cmd string) SuspiciousCmd {
 		"wget",
 		"alias",
 		"dd",
+		"unset",
 		"linpeas",
 		"getfacl",
 		"setfacl",

--- a/logmon/logmon.go
+++ b/logmon/logmon.go
@@ -3,8 +3,16 @@ package logmon
 import (
 	"os"
 	"time"
+	"os/exec"
+	"strings"
+	"strconv"
+	"fmt"
+	"errors"
 
 	"github.com/xFaraday/gomemento/hookmon"
+	"github.com/xFaraday/gomemento/webmon"
+	"github.com/xFaraday/gomemento/alertmon"
+
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -51,6 +59,186 @@ func getEncoder() zapcore.Encoder {
 	encoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder
 	return zapcore.NewConsoleEncoder(encoderConfig)
 }
+
+
+//filepath should be a utmp, wtmp, or btmp file which has info about logins
+	// /var/run/utmp
+	// /var/log/wtmp
+	// /var/log/btmp
+// Resource: https://sandflysecurity.com/blog/using-linux-utmpdump-for-forensics-and-detecting-log-file-tampering/
+func DetectTampering(filepath string) {
+	fmt.Println("[+] Inspecting: " + filepath)
+	fileBytes, _ := exec.Command("bash", "-c", "utmpdump " + filepath).Output()
+	// loop through each line of the log file, attempt to find the date which indicates tampering
+	for _, line := range strings.Split(string(fileBytes), "\n") {
+		// last log file field contains the date, we only want that
+		if len(line) != 0 {
+			logFileFields := strings.Fields(line)
+			timestampField := logFileFields[len(logFileFields)-1]
+			// if log file timestamp field contains suspicious date, may be indication of tampering
+			if strings.Contains(timestampField, "1970-01-01") {
+				// send alert about potential tampering w/log files
+				/* alert should contain: 
+					* log file tampered with 
+					* IP addr of machine
+					* hostname of machine
+				*/
+				fmt.Println("[!] Potential tampering has occurred!")
+				// generate log report
+				zlog := zap.S().With(
+					"REASON:", "Potential login log file tampering",
+					"Log File Location:", filepath,
+					"Metholodgy:", "The log file contained the timestamp 1970-01-01 which indicates that an event was nulled out",
+				)
+				zlog.Warn("Potential log file tampering detected with login log files")
+
+				// generate alert
+				var inc alertmon.Incident = alertmon.Incident{
+					Name:	"Log file tampering with the following log file: " + filepath,
+					User:	"",
+					Process:	"",
+					RemoteIP:	"",
+					Cmd:	"",
+				}
+
+				IP := webmon.GetIP()
+				hostname := "host-" + strings.Split(IP, ".")[3]
+				var alert alertmon.Alert = alertmon.Alert{
+					Host:	hostname,
+					Incident:	inc,
+				}
+				webmon.IncidentAlert(alert)
+				
+			}
+		}
+	}
+}
+
+/* determine which log file(s) to use:
+	/var/run/utmp
+	/var/log/wtmp
+	/var/log/btmp
+*/
+// First run FindBadLoginFile(), it'll return a slice w/the locations in which bad logins are logged
+// Then loop through that slice & run DetectTampering() on each log path returned by FindBadLoginFile()
+func FindBadLoginFile() []string {
+	fmt.Println("[+] Finding bad login log files...")
+	possibleLogFileLocations := []string{"/var/run/utmp", "/var/log/wtmp", "/var/log/btmp"}
+	validLogFileLocations := []string{}
+	for _, file := range possibleLogFileLocations {
+		// create slice of all log files that exist, return it
+		_, err := os.Stat(file)
+		// if file doesn't exist
+		if errors.Is(err, os.ErrNotExist) {
+			fmt.Println("[!] " + file + " doesn't exist on this system!")
+		} else {
+			validLogFileLocations = append(validLogFileLocations, file)
+		}
+
+	}
+
+	return validLogFileLocations
+}
+
+type FailLogData struct {
+	user	string
+	failct	string
+	latestlogin	string
+}
+
+func ReportFailedLoginCount(username string) {
+	if username == "all" {
+		failLogOut, err := exec.Command("bash", "-c", "user=$(awk -F ':' '{ print $1}' /etc/passwd);for i in $user; do faillog -u $i; done").Output()
+		if err != nil {
+			fmt.Println(err)
+		}
+		failLogOutSplit := strings.Split(string(failLogOut), "\n")
+		// loop through each user's faillog stats
+		for _, line := range failLogOutSplit {
+			if line != "Login       Failures Maximum Latest                   On" && len(line) != 0 {
+				// split on each space so we can parse each log
+				fields := strings.Fields(line)	
+				// check if the amount of failures is over 3
+				failureCtInt, _ := strconv.Atoi(fields[1])
+				if failureCtInt > 3 {
+					// send alert since login failures is over 3
+					fmt.Println("[!] Login failures for user: " + fields[0] + " is over 3!")
+					// generate log report
+					zlog := zap.S().With(
+						"REASON:", "Failed login count exceeds 3!",
+						"Username:", fields[0],
+						"Metholodgy:", "Used faillog to detect amount of failed logins",
+					)
+					zlog.Warn("Failed login count exceeds 3!")
+
+					// generate alert
+					var inc alertmon.Incident = alertmon.Incident{
+						Name:	"Failed login count for following user exceeds 3: " + fields[0],
+						User:	fields[0],
+						Process:	"",
+						RemoteIP:	"",
+						Cmd:	"",
+					}
+
+					IP := webmon.GetIP()
+					hostname := "host-" + strings.Split(IP, ".")[3]
+					var alert alertmon.Alert = alertmon.Alert{
+						Host:	hostname,
+						Incident:	inc,
+					}
+					webmon.IncidentAlert(alert)
+				} else {
+					fmt.Println("[+] Failed logins are below 3 for user: " + fields[0])
+				}
+			}
+		}
+	} else {
+		failLogOut, err := exec.Command("bash", "-c", "faillog -u " + username).Output()
+		if err != nil {
+			fmt.Println(err)
+		}
+		failLogOutSplit := strings.Split(string(failLogOut), "\n")
+		for _, line := range failLogOutSplit {
+			if line != "Login       Failures Maximum Latest                   On" && len(line) != 0 {
+				fields := strings.Fields(line)
+				// check if amount of failures is over 3
+				failureCtInt, _ := strconv.Atoi(fields[1])
+				if failureCtInt > 3 {
+					// send alert since login failures is over 3
+					fmt.Println("[!] Login failures for user: " + fields[0] + " is over 3!")
+					// generate log report
+					zlog := zap.S().With(
+						"REASON:", "Failed login count exceeds 3!",
+						"Username:", fields[0],
+						"Metholodgy:", "Used faillog to detect amount of failed logins",
+					)
+					zlog.Warn("Failed login count exceeds 3!")
+
+					// generate alert
+					var inc alertmon.Incident = alertmon.Incident{
+						Name:	"Failed login count for following user exceeds 3: " + fields[0],
+						User:	fields[0],
+						Process:	"",
+						RemoteIP:	"",
+						Cmd:	"",
+					}
+
+					IP := webmon.GetIP()
+					hostname := "host-" + strings.Split(IP, ".")[3]
+					var alert alertmon.Alert = alertmon.Alert{
+						Host:	hostname,
+						Incident:	inc,
+					}
+					webmon.IncidentAlert(alert)
+				} else {
+					fmt.Println("[+] Failed login count is below 3 for user: " + fields[0])
+				}
+			}
+		}
+	}
+}
+
+
 
 func LogGuardian() {
 	/*

--- a/main.go
+++ b/main.go
@@ -114,6 +114,13 @@ func main() {
 	case 9:
 		IP := config.GetSerialScripterIP()
 		println(IP)
+	case 10: // tampering detection for following files: /var/run/utmp, /var/log/wtmp/, /var/log/btmp
+		badLoginFileSlice := logmon.FindBadLoginFile()
+		for _, file := range badLoginFileSlice {
+			logmon.DetectTampering(file)
+		}
+	case 11: // run faillog on all users on system, if the failure count exceeds 3, send alert
+		logmon.ReportFailedLoginCount("all") 
 	case 1337:
 		frontend.QuickInterface()
 	case 31337:


### PR DESCRIPTION
Within logmon.go:

* Added ability to detect tampering with log files that track bad logins, such as: /var/run/utmp, /var/log/wtmp, & /var/log/btmp 
	* Methodology for detecting tampering is if the date 1970-01-01 exists within any lines of the log file which may be indication of tampering: https://sandflysecurity.com/blog/using-linux-utmpdump-for-forensics-and-detecting-log-file-tampering/
	* FindBadLoginFile() will loop through those 3 login log files & determine which exists
	* Then DetectTampering() is ran on the login log files that exist
* Added ability to loop through each user on a system & run faillog on the user, then determine whether or not their login failure count is above 3
	* If it's above 3, we send an alert
	* Can also run faillog on a specific user instead of looping through each user on the system
	
Within cmdmon.go:

* added unset cmd to list of suspicious linux commands in order to detect when attacker disables bash history recording